### PR TITLE
Auto-emit \FloatBarrier between figures in LaTeX (issue 27)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # ggtibble 1.0.2.9000
 
+* `knit_print.gglist()` automatically inserts `\FloatBarrier` between
+  figures when more than 10 plots are rendered to LaTeX, avoiding the
+  LaTeX "Output loop---100 consecutive dead cycles" error.  The
+  threshold is configurable via the new `float_barrier_after` argument
+  (default `10`; use `Inf` to disable).  Requires `\usepackage{placeins}`
+  in the document preamble. (#27)
 * New exported S3 generic `as_gglist()` (methods for `gg`, `list`, `gglist`,
   `labels`, and `NULL`) that promotes an input to a `gglist`.  When the input
   uses `ggforce::facet_wrap_paginate()` or `ggforce::facet_grid_paginate()`,

--- a/R/gglist.R
+++ b/R/gglist.R
@@ -136,11 +136,30 @@ knitr::knit_print
 #' `sprintf()` must be met; for example, if you want a percent sign ("%") in the
 #' filename, it must be doubled so that sprintf returns what is desired.
 #'
+#' When `length(x)` exceeds `float_barrier_after` and the output format is
+#' LaTeX (as detected by `knitr::is_latex_output()`), `fig_suffix` defaults to
+#' `"\n\n\\FloatBarrier\n\n"` instead of the usual `"\n\n"`.  This avoids the
+#' LaTeX "Output loop---100 consecutive dead cycles" error that occurs when
+#' the float queue (default capacity ~18) overflows.  `\FloatBarrier` is
+#' provided by the `placeins` LaTeX package, which is *not* loaded by default
+#' in `rmarkdown::pdf_document`; add `\usepackage{placeins}` to the document
+#' preamble (e.g. via `header-includes` in the YAML) when relying on the
+#' auto-suffix.  Pass `fig_suffix` explicitly to override, or set
+#' `float_barrier_after = Inf` to disable the auto-suffix entirely.
+#'
 #' @param x The gglist object
 #' @param ... extra arguments to `knit_print()`
 #' @param filename A filename with an optional "%d" sprintf pattern for saving
 #'   the plots
-#' @param fig_suffix Any text to add after the figure
+#' @param fig_suffix Any text to add after the figure.  Defaults to `NULL`,
+#'   which means "auto-select": `"\n\n\\FloatBarrier\n\n"` for LaTeX output
+#'   when `length(x) > float_barrier_after`, otherwise `"\n\n"`.
+#' @param float_barrier_after Numeric threshold for emitting `\FloatBarrier`
+#'   between figures in LaTeX output.  When `length(x) > float_barrier_after`
+#'   and `knitr::is_latex_output()` is `TRUE` and the user did not supply
+#'   `fig_suffix`, `fig_suffix` defaults to `"\n\n\\FloatBarrier\n\n"`.  Has
+#'   no effect on non-LaTeX output.  Set to `Inf` to disable.  Defaults to
+#'   `10`.
 #' @return The list, invisibly
 #' @family knitters
 #' @examples
@@ -154,7 +173,14 @@ knitr::knit_print
 #'   ggplot2::geom_point()
 #' knit_print(p, fig_suffix = "\n\n\\FloatBarrier\n\n")
 #' @export
-knit_print.gglist <- function(x, ..., filename = NULL, fig_suffix = "\n\n") {
+knit_print.gglist <- function(x, ..., filename = NULL, fig_suffix = NULL, float_barrier_after = 10) {
+  checkmate::assert_number(float_barrier_after, lower = 0, na.ok = FALSE)
+  if (is.null(fig_suffix)) {
+    fig_suffix <- "\n\n"
+    if (length(x) > float_barrier_after && knitr::is_latex_output()) {
+      fig_suffix <- "\n\n\\FloatBarrier\n\n"
+    }
+  }
   if (!is.null(filename)) {
     if (length(filename) == length(x)) {
       # do nothing

--- a/man/knit_print.gg.Rd
+++ b/man/knit_print.gg.Rd
@@ -22,7 +22,9 @@
 
 \item{fig_prefix}{Text to \code{cat()} before the figure is printed}
 
-\item{fig_suffix}{Any text to add after the figure}
+\item{fig_suffix}{Any text to add after the figure.  Defaults to \code{NULL},
+which means "auto-select": \code{"\\n\\n\\\\FloatBarrier\\n\\n"} for LaTeX output
+when \code{length(x) > float_barrier_after}, otherwise \code{"\\n\\n"}.}
 
 \item{filename}{A filename saving the plot}
 

--- a/man/knit_print.gglist.Rd
+++ b/man/knit_print.gglist.Rd
@@ -5,7 +5,13 @@
 \alias{knit_print.ggtibble}
 \title{Print a list of plots made by gglist}
 \usage{
-\method{knit_print}{gglist}(x, ..., filename = NULL, fig_suffix = "\\n\\n")
+\method{knit_print}{gglist}(
+  x,
+  ...,
+  filename = NULL,
+  fig_suffix = NULL,
+  float_barrier_after = 10
+)
 
 \method{knit_print}{ggtibble}(x, ...)
 }
@@ -17,7 +23,16 @@
 \item{filename}{A filename with an optional "\%d" sprintf pattern for saving
 the plots}
 
-\item{fig_suffix}{Any text to add after the figure}
+\item{fig_suffix}{Any text to add after the figure.  Defaults to \code{NULL},
+which means "auto-select": \code{"\\n\\n\\\\FloatBarrier\\n\\n"} for LaTeX output
+when \code{length(x) > float_barrier_after}, otherwise \code{"\\n\\n"}.}
+
+\item{float_barrier_after}{Numeric threshold for emitting \verb{\\FloatBarrier}
+between figures in LaTeX output.  When \code{length(x) > float_barrier_after}
+and \code{knitr::is_latex_output()} is \code{TRUE} and the user did not supply
+\code{fig_suffix}, \code{fig_suffix} defaults to \code{"\\n\\n\\\\FloatBarrier\\n\\n"}.  Has
+no effect on non-LaTeX output.  Set to \code{Inf} to disable.  Defaults to
+\code{10}.}
 }
 \value{
 The list, invisibly
@@ -30,6 +45,18 @@ is searched for and if found, then the filename will be generated using that
 \code{sprintf()} format.  Note that also means that other requirements for
 \code{sprintf()} must be met; for example, if you want a percent sign ("\%") in the
 filename, it must be doubled so that sprintf returns what is desired.
+}
+\details{
+When \code{length(x)} exceeds \code{float_barrier_after} and the output format is
+LaTeX (as detected by \code{knitr::is_latex_output()}), \code{fig_suffix} defaults to
+\code{"\\n\\n\\\\FloatBarrier\\n\\n"} instead of the usual \code{"\\n\\n"}.  This avoids the
+LaTeX "Output loop---100 consecutive dead cycles" error that occurs when
+the float queue (default capacity ~18) overflows.  \verb{\\FloatBarrier} is
+provided by the \code{placeins} LaTeX package, which is \emph{not} loaded by default
+in \code{rmarkdown::pdf_document}; add \verb{\\usepackage\{placeins\}} to the document
+preamble (e.g. via \code{header-includes} in the YAML) when relying on the
+auto-suffix.  Pass \code{fig_suffix} explicitly to override, or set
+\code{float_barrier_after = Inf} to disable the auto-suffix entirely.
 }
 \section{Functions}{
 \itemize{

--- a/tests/testthat/test-gglist.R
+++ b/tests/testthat/test-gglist.R
@@ -129,6 +129,64 @@ test_that("knit_print.gg", {
   expect_output(knit_print(p, fig_suffix = "suffix"), "suffix")
 })
 
+# knit_print.gglist LaTeX float-barrier behavior (issue #27) ####
+
+test_that("knit_print.gglist auto-emits FloatBarrier when many plots in LaTeX", {
+  many <- new_gglist(replicate(11, ggplot2::ggplot(environment = emptyenv()), simplify = FALSE))
+  testthat::local_mocked_bindings(is_latex_output = function() TRUE, .package = "knitr")
+  expect_output(knit_print(many), "\\FloatBarrier", fixed = TRUE)
+})
+
+test_that("knit_print.gglist does not emit FloatBarrier at or below the threshold", {
+  ten <- new_gglist(replicate(10, ggplot2::ggplot(environment = emptyenv()), simplify = FALSE))
+  testthat::local_mocked_bindings(is_latex_output = function() TRUE, .package = "knitr")
+  out <- capture.output(knit_print(ten))
+  expect_false(any(grepl("FloatBarrier", out, fixed = TRUE)))
+})
+
+test_that("knit_print.gglist does not emit FloatBarrier in non-LaTeX output", {
+  many <- new_gglist(replicate(11, ggplot2::ggplot(environment = emptyenv()), simplify = FALSE))
+  testthat::local_mocked_bindings(is_latex_output = function() FALSE, .package = "knitr")
+  out <- capture.output(knit_print(many))
+  expect_false(any(grepl("FloatBarrier", out, fixed = TRUE)))
+})
+
+test_that("user-supplied fig_suffix overrides the auto FloatBarrier", {
+  many <- new_gglist(replicate(11, ggplot2::ggplot(environment = emptyenv()), simplify = FALSE))
+  testthat::local_mocked_bindings(is_latex_output = function() TRUE, .package = "knitr")
+  out <- capture.output(knit_print(many, fig_suffix = "USER_SUFFIX"))
+  expect_false(any(grepl("FloatBarrier", out, fixed = TRUE)))
+  expect_true(any(grepl("USER_SUFFIX", out, fixed = TRUE)))
+})
+
+test_that("float_barrier_after = Inf disables the auto FloatBarrier", {
+  many <- new_gglist(replicate(11, ggplot2::ggplot(environment = emptyenv()), simplify = FALSE))
+  testthat::local_mocked_bindings(is_latex_output = function() TRUE, .package = "knitr")
+  out <- capture.output(knit_print(many, float_barrier_after = Inf))
+  expect_false(any(grepl("FloatBarrier", out, fixed = TRUE)))
+})
+
+test_that("float_barrier_after rejects invalid values", {
+  one <- new_gglist(list(ggplot2::ggplot(environment = emptyenv())))
+  expect_error(knit_print(one, float_barrier_after = -1))
+  expect_error(knit_print(one, float_barrier_after = NA))
+  expect_error(knit_print(one, float_barrier_after = c(1, 2)))
+  expect_error(knit_print(one, float_barrier_after = "10"))
+})
+
+test_that("knit_print.ggtibble inherits LaTeX float-barrier behavior", {
+  d_plot <- data.frame(A = 1:11, B = 1:11, C = 1:11)
+  gt <- ggtibble(
+    d_plot,
+    ggplot2::aes(x = B, y = C),
+    outercols = "A",
+    caption = "{A}"
+  )
+  expect_equal(nrow(gt), 11)
+  testthat::local_mocked_bindings(is_latex_output = function() TRUE, .package = "knitr")
+  expect_output(knit_print(gt), "\\FloatBarrier", fixed = TRUE)
+})
+
 # Trivial tests for 100% coverage ####
 
 test_that("gglist trivial", {


### PR DESCRIPTION
## Summary
- `knit_print.gglist()` gains a `float_barrier_after` argument (default `10`). When `length(x) > float_barrier_after` AND `knitr::is_latex_output()` is `TRUE` AND the user did not pass `fig_suffix`, `\FloatBarrier` is auto-emitted between figures.
- Fixes the LaTeX "Output loop---100 consecutive dead cycles" error from float-queue overflow on many-figure ggtibbles ([humanpred/ggtibble issue 27](https://github.com/humanpred/ggtibble/issues/27)).
- Inherited automatically by `knit_print.ggtibble()` via `...` forwarding. No behavior change for non-LaTeX output. Pass `fig_suffix` explicitly or set `float_barrier_after = Inf` to opt out. Requires `\usepackage{placeins}` in the LaTeX preamble.

## Test plan
- [x] `devtools::test()` — 192 passed, 0 failed (12 new expectations across 7 new tests in `test-gglist.R`)
- [x] `devtools::check()` — 0 errors, 0 warnings, 1 NOTE (pre-existing `.git` worktree artifact)
- [x] Tests cover: auto-trigger above threshold, no-trigger at/below threshold, no-trigger in non-LaTeX output, user `fig_suffix` override, `Inf` opt-out, input validation (negative, `NA`, length > 1, non-numeric), and inheritance through `knit_print.ggtibble()`
- [ ] Manual smoke test: render a ≥11-row ggtibble to PDF with `header-includes: \usepackage{placeins}` and confirm no LaTeX dead-cycle error; render the same to HTML and confirm `\FloatBarrier` does not appear in the output

Fix #27